### PR TITLE
Made updates to the BaseConnector to use CRUD operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,6 @@ dependencies = [
     "stripe>=12.1.0",
 ]
 
-[project.scripts]
-rev-connectors = "rev_connectors:main"
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/rev_connectors/__init__.py
+++ b/src/rev_connectors/__init__.py
@@ -2,28 +2,23 @@ import polars as pl
 
 from abc import ABC, abstractmethod
 
-def main() -> None:
-    print("Hello from rev-connectors!")
 
 class BaseConnector(ABC):
     @abstractmethod
     def __init__(self, df: pl.DataFrame) -> None:
         ...
 
-    @abstractmethod
-    def query(self) -> pl.DataFrame:
-        ...
-
+    # Abstract methods for CRUD operations
     @abstractmethod
     def create(self) -> pl.DataFrame:
         ...
 
     @abstractmethod
-    def update(self) -> pl.DataFrame:
+    def read(self) -> pl.DataFrame:
         ...
 
     @abstractmethod
-    def upsert(self) -> pl.DataFrame:
+    def update(self) -> pl.DataFrame:
         ...
 
     @abstractmethod

--- a/src/rev_connectors/billingplatform.py
+++ b/src/rev_connectors/billingplatform.py
@@ -8,16 +8,13 @@ class BillingPlatform(BaseConnector):
     def __init__(self, df: pl.DataFrame) -> None:
         self._df = df
 
-    def query(self) -> pl.DataFrame:
-        ...
-
     def create(self) -> pl.DataFrame:
         ...
 
-    def update(self) -> pl.DataFrame:
+    def read(self) -> pl.DataFrame:
         ...
 
-    def upsert(self) -> pl.DataFrame:
+    def update(self) -> pl.DataFrame:
         ...
 
     def delete(self) -> pl.DataFrame:

--- a/src/rev_connectors/chuck.py
+++ b/src/rev_connectors/chuck.py
@@ -4,23 +4,22 @@ import requests
 from . import BaseConnector
 
 
+# Chuck Norris Joke API Connector
+# This is connector is for demonstration purposes only to help guide the creation of new connectors.
 @pl.api.register_dataframe_namespace('chuck')
 class Chuck(BaseConnector):
     def __init__(self, df: pl.DataFrame) -> None:
         self._df = df
 
-    def query(self) -> pl.DataFrame:
+    def create(self) -> pl.DataFrame:
+        ...
+
+    def read(self) -> pl.DataFrame:
         random_joke = requests.get('https://api.chucknorris.io/jokes/random')
         jokes: list[dict] = [random_joke.json()]
         return pl.DataFrame(jokes)
 
-    def create(self) -> pl.DataFrame:
-        ...
-
     def update(self) -> pl.DataFrame:
-        ...
-
-    def upsert(self) -> pl.DataFrame:
         ...
 
     def delete(self) -> pl.DataFrame:

--- a/tests/billingplatform.py
+++ b/tests/billingplatform.py
@@ -1,6 +1,8 @@
 import requests
 
+
 bp_session = requests.Session()
+
 bp_session.headers.update({
     "username": "my.username",
     "password": "password",

--- a/tests/chuck.py
+++ b/tests/chuck.py
@@ -5,5 +5,5 @@ from rev_connectors import chuck
 
 # Make a call to the Chuck Norris API for a random joke
 # Return as a DataFrame
-chuck_joke_df = pl.DataFrame().chuck.query()
+chuck_joke_df = pl.DataFrame().chuck.read()
 print(chuck_joke_df)


### PR DESCRIPTION
I made a change to the BaseConnector to use CRUD methods as the default. It makes more sense given that not all platforms will have something called 'query' or 'upsert'. I believe it is best to keep things generic for now.